### PR TITLE
feat: Add optional StartEndpoint support for idle watcher

### DIFF
--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -28,16 +28,17 @@ type (
 		PrivateIP          string      `json:"private_ip"`
 		NetworkMode        string      `json:"network_mode"`
 
-		Aliases     []string `json:"aliases"`
-		IsExcluded  bool     `json:"is_excluded"`
-		IsExplicit  bool     `json:"is_explicit"`
-		IsDatabase  bool     `json:"is_database"`
-		IdleTimeout string   `json:"idle_timeout,omitempty"`
-		WakeTimeout string   `json:"wake_timeout,omitempty"`
-		StopMethod  string   `json:"stop_method,omitempty"`
-		StopTimeout string   `json:"stop_timeout,omitempty"` // stop_method = "stop" only
-		StopSignal  string   `json:"stop_signal,omitempty"`  // stop_method = "stop" | "kill" only
-		Running     bool     `json:"running"`
+		Aliases       []string `json:"aliases"`
+		IsExcluded    bool     `json:"is_excluded"`
+		IsExplicit    bool     `json:"is_explicit"`
+		IsDatabase    bool     `json:"is_database"`
+		IdleTimeout   string   `json:"idle_timeout,omitempty"`
+		WakeTimeout   string   `json:"wake_timeout,omitempty"`
+		StopMethod    string   `json:"stop_method,omitempty"`
+		StopTimeout   string   `json:"stop_timeout,omitempty"` // stop_method = "stop" only
+		StopSignal    string   `json:"stop_signal,omitempty"`  // stop_method = "stop" | "kill" only
+		StartEndpoint string   `json:"start_endpoint,omitempty"`
+		Running       bool     `json:"running"`
 	}
 )
 
@@ -58,16 +59,17 @@ func FromDocker(c *types.Container, dockerHost string) (res *Container) {
 		PrivatePortMapping: helper.getPrivatePortMapping(),
 		NetworkMode:        c.HostConfig.NetworkMode,
 
-		Aliases:     helper.getAliases(),
-		IsExcluded:  strutils.ParseBool(helper.getDeleteLabel(LabelExclude)),
-		IsExplicit:  isExplicit,
-		IsDatabase:  helper.isDatabase(),
-		IdleTimeout: helper.getDeleteLabel(LabelIdleTimeout),
-		WakeTimeout: helper.getDeleteLabel(LabelWakeTimeout),
-		StopMethod:  helper.getDeleteLabel(LabelStopMethod),
-		StopTimeout: helper.getDeleteLabel(LabelStopTimeout),
-		StopSignal:  helper.getDeleteLabel(LabelStopSignal),
-		Running:     c.Status == "running" || c.State == "running",
+		Aliases:       helper.getAliases(),
+		IsExcluded:    strutils.ParseBool(helper.getDeleteLabel(LabelExclude)),
+		IsExplicit:    isExplicit,
+		IsDatabase:    helper.isDatabase(),
+		IdleTimeout:   helper.getDeleteLabel(LabelIdleTimeout),
+		WakeTimeout:   helper.getDeleteLabel(LabelWakeTimeout),
+		StopMethod:    helper.getDeleteLabel(LabelStopMethod),
+		StopTimeout:   helper.getDeleteLabel(LabelStopTimeout),
+		StopSignal:    helper.getDeleteLabel(LabelStopSignal),
+		StartEndpoint: helper.getDeleteLabel(LabelStartEndpoint),
+		Running:       c.Status == "running" || c.State == "running",
 	}
 	res.setPrivateIP(helper)
 	res.setPublicIP()

--- a/internal/docker/idlewatcher/types/config_test.go
+++ b/internal/docker/idlewatcher/types/config_test.go
@@ -1,0 +1,47 @@
+package types
+
+import (
+	"testing"
+
+	. "github.com/yusing/go-proxy/internal/utils/testing"
+)
+
+func TestValidateStartEndpoint(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "valid",
+			input:   "/start",
+			wantErr: false,
+		},
+		{
+			name:    "invalid",
+			input:   "../foo",
+			wantErr: true,
+		},
+		{
+			name:    "single fragment",
+			input:   "#",
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			input:   "",
+			wantErr: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := validateStartEndpoint(tc.input)
+			if err == nil {
+				ExpectEqual(t, s, tc.input)
+			}
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateStartEndpoint() error = %v, wantErr %t", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/docker/idlewatcher/waker_http.go
+++ b/internal/docker/idlewatcher/waker_http.go
@@ -34,6 +34,12 @@ func (w *Watcher) wakeFromHTTP(rw http.ResponseWriter, r *http.Request) (shouldN
 		return true
 	}
 
+	// Check if start endpoint is configured and request path matches
+	if w.StartEndpoint != "" && r.URL.Path != w.StartEndpoint {
+		http.Error(rw, "Forbidden: Container can only be started via configured start endpoint", http.StatusForbidden)
+		return false
+	}
+
 	if r.Body != nil {
 		defer r.Body.Close()
 	}

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -5,11 +5,12 @@ const (
 
 	NSProxy = "proxy"
 
-	LabelAliases     = NSProxy + ".aliases"
-	LabelExclude     = NSProxy + ".exclude"
-	LabelIdleTimeout = NSProxy + ".idle_timeout"
-	LabelWakeTimeout = NSProxy + ".wake_timeout"
-	LabelStopMethod  = NSProxy + ".stop_method"
-	LabelStopTimeout = NSProxy + ".stop_timeout"
-	LabelStopSignal  = NSProxy + ".stop_signal"
+	LabelAliases       = NSProxy + ".aliases"
+	LabelExclude       = NSProxy + ".exclude"
+	LabelIdleTimeout   = NSProxy + ".idle_timeout"
+	LabelWakeTimeout   = NSProxy + ".wake_timeout"
+	LabelStopMethod    = NSProxy + ".stop_method"
+	LabelStopTimeout   = NSProxy + ".stop_timeout"
+	LabelStopSignal    = NSProxy + ".stop_signal"
+	LabelStartEndpoint = NSProxy + ".start_endpoint"
 )


### PR DESCRIPTION
Optionally allow a user to specify a “warm-up” endpoint to start the container, returning a 403 if the endpoint isn’t hit and the container has been stopped.

This can help prevent bots from starting random containers, or allow health check systems to run some probes. Or potentially lock the start endpoints behind a different authentication mechanism, etc.

Sample service showing this:

```yaml
  hello-world:
    image: nginxdemos/hello
    container_name: hello-world
    restart: "no"
    ports:
      - "9100:80"
    labels:
      proxy.aliases: hello-world
      proxy.#1.port: 9100
      proxy.idle_timeout: 45s
      proxy.wake_timeout: 30s
      proxy.stop_method: stop
      proxy.stop_timeout: 10s
      proxy.stop_signal: SIGTERM
      proxy.start_endpoint: "/start"
```

Hitting `/` on this service when the container is down:

```curl
$ curl -sv -X GET -H "Host: hello-world.godoxy.local" http://localhost/
* Host localhost:80 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:80...
* Connected to localhost (::1) port 80
> GET / HTTP/1.1
> Host: hello-world.godoxy.local
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 403 Forbidden
< Content-Type: text/plain; charset=utf-8
< X-Content-Type-Options: nosniff
< Date: Wed, 08 Jan 2025 02:04:51 GMT
< Content-Length: 71
< 
Forbidden: Container can only be started via configured start endpoint
* Connection #0 to host localhost left intact
```

Hitting `/start` when the container is down:

```curl
curl -sv -X GET -H "Host: hello-world.godoxy.local" -H "X-Goproxy-Check-Redirect: skip" http://localhost/start
* Host localhost:80 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:80...
* Connected to localhost (::1) port 80
> GET /start HTTP/1.1
> Host: hello-world.godoxy.local
> User-Agent: curl/8.7.1
> Accept: */*
> X-Goproxy-Check-Redirect: skip
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Date: Wed, 08 Jan 2025 02:13:39 GMT
< Content-Length: 0
< 
* Connection #0 to host localhost left intact
```