### PR TITLE
fix: allow oauth_state token to be cross-domain

### DIFF
--- a/internal/api/v1/auth/oidc.go
+++ b/internal/api/v1/auth/oidc.go
@@ -60,7 +60,8 @@ func OIDCLoginHandler(w http.ResponseWriter, r *http.Request) {
 		Value:    state,
 		MaxAge:   300,
 		HttpOnly: true,
-		SameSite: http.SameSiteStrictMode,
+		SameSite: http.SameSiteNoneMode,
+		Secure:   true,
 		Path:     "/",
 	})
 


### PR DESCRIPTION
External OIDC providers won’t work with the current setup.